### PR TITLE
apiRequest method: using callbacks inside instead of events 

### DIFF
--- a/lib/fuel-rest.js
+++ b/lib/fuel-rest.js
@@ -50,8 +50,13 @@ FuelRest.prototype.apiRequest = function( type, uri, options, callback ) {
 	authOptions.forceRequest   = authOptions.forceRequest || null;
 	authOptions.requestOptions = authOptions.requestOptions || null;
 
-	this.AuthClient.once( 'response', function( body ) {
+	this.AuthClient.getAccessToken( authOptions.requestOptions, authOptions.forceRequest, function( err, body ) {
 		var localError;
+
+		if( !!err ) {
+			this._deliverResponse( 'error', err, callback, 'FuelAuth' );
+			return;
+		}
 
 		// if there's no access token we have a problem
 		if( !body.accessToken ) {
@@ -89,13 +94,8 @@ FuelRest.prototype.apiRequest = function( type, uri, options, callback ) {
 			this._deliverResponse( 'response', { res: res, body: parsedBody }, callback );
 
 		}.bind( this ) );
-	}.bind( this ) );
 
-	this.AuthClient.once( 'error', function( err ) {
-		this._deliverResponse( 'error', err, callback, 'FuelAuth' );
 	}.bind( this ) );
-
-	this.AuthClient.getAccessToken( authOptions.requestOptions, authOptions.forceRequest );
 };
 
 FuelRest.prototype.get = function( uri, options, callback ) {


### PR DESCRIPTION
because of parallel invocation
