### PR TITLE
It's possible that the content-type header won't exist

### DIFF
--- a/lib/fuel-rest.js
+++ b/lib/fuel-rest.js
@@ -122,7 +122,7 @@ FuelRest.prototype.apiRequest = function( options, callback ) {
 			}
 
 			// checking to make sure it's json from api
-			if( res.headers[ 'content-type' ].split( ';' )[ 0 ].toLowerCase() !== 'application/json' ) {
+			if( !res.headers[ 'content-type' ] || res.headers[ 'content-type' ].split( ';' )[ 0 ].toLowerCase() !== 'application/json' ) {
 				helpers.deliverResponse( 'error', new Error( 'API did not return JSON' ), callback, 'Fuel REST' );
 				return;
 			}


### PR DESCRIPTION
In some cases (for example, on certain 500 errors) a content-type header won't be present
