### PR TITLE
Use FuelAuth Promises Internally

### DIFF
--- a/lib/fuel-rest.js
+++ b/lib/fuel-rest.js
@@ -73,42 +73,40 @@ class FuelRest {
 		});
 	}
 	_processRequest(options, callback) {
-		this.AuthClient.getAccessToken(clone(options.auth), (err, authResponse) => {
-			let retry = false;
-			const consolidatedOpts = {};
+		this.AuthClient.getAccessToken(clone(options.auth))
+			.then(tokenInfo => {
+				if (!tokenInfo.accessToken) {
+					let error = new Error('No access token');
+					error.res = tokenInfo;
 
-			if (err) {
-				callback(err, null);
-				return;
-			}
+					return Promise.reject(error);
+				}
+				return tokenInfo;
+			})
+			.then(tokenInfo => {
+				let retry = false;
+				const consolidatedOpts = {};
+				const authOptions = clone(options.auth);
 
-			if (!authResponse.accessToken) {
-				let localError = new Error('No access token');
-				localError.res = authResponse;
-				callback(localError, null);
-				return;
-			}
+				options.uri = helpers.resolveUri(this.origin, options.uri);
+				options.headers = Object.assign({}, this.defaultHeaders, options.headers);
 
-			const authOptions = clone(options.auth);
+				if (!options.headers.Authorization) {
+					options.headers.Authorization = 'Bearer ' + tokenInfo.accessToken;
+					retry = options.retry || false;
+				}
 
-			options.uri = helpers.resolveUri(this.origin, options.uri);
-			options.headers = Object.assign({}, this.defaultHeaders, options.headers);
+				delete options.retry;
+				delete options.auth;
 
-			if (!options.headers.Authorization) {
-				options.headers.Authorization = 'Bearer ' + authResponse.accessToken;
-				retry = options.retry || false;
-			}
+				consolidatedOpts.req = options;
+				consolidatedOpts.auth = authOptions;
+				consolidatedOpts.accessToken = tokenInfo.accessToken;
+				consolidatedOpts.retry = retry;
 
-			delete options.retry;
-			delete options.auth;
-
-			consolidatedOpts.req = options;
-			consolidatedOpts.auth = authOptions;
-			consolidatedOpts.accessToken = authResponse.accessToken;
-			consolidatedOpts.retry = retry;
-
-			this._makeRequest(consolidatedOpts, callback);
-		});
+				this._makeRequest(consolidatedOpts, callback);
+			})
+			.catch(err => callback(err, null));
 	}
 	_makeRequest(consolidatedOpts, callback) {
 		const requestOptions = consolidatedOpts.req;
@@ -155,6 +153,7 @@ class FuelRest {
 	/**
 	 * Method that makes the GET api request
 	 * @param {Object} options - request modules options. see https://github.com/request/request#requestoptions-callback
+	 * @param {Object} options.auth - force the retrieval of a new access token
 	 * @param {boolean} options.auth.force - force the retrieval of a new access token
 	 * @param {boolean} [options.retry=true] - force a retry if request fails due to token expiration
 	 * @param {function} callback - callback to give results to. if not specified promise will be returned

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Node library for performing REST API calls to Salesforce Marketing Cloud (formerly ExactTarget).",
   "main": "./lib/fuel-rest.js",
   "scripts": {
-    "test": "node ./node_modules/.bin/gulp ci"
+    "test": "node ./node_modules/.bin/gulp ci",
+    "test:watch": "node ./node_modules/.bin/mocha ./test/specs/**/*.js --reporter=spec --watch"
   },
   "engines": {
     "node": ">= 4"

--- a/test/mock-server.js
+++ b/test/mock-server.js
@@ -11,18 +11,18 @@ const _ = require('lodash');
 const validUrls = require('./config').routes;
 const sampleResponses = require('./sample-responses');
 
-module.exports = function(port) {
+module.exports = port => {
 	'use strict';
 
 	return http
-		.createServer(function(req, res) {
-			var sendResponse = function(res, status, data) {
+		.createServer((req, res) => {
+			const sendResponse = (res, status, data) => {
 				res.statusCode = status;
 				res.end(JSON.stringify(data));
 			};
 
-			var _bodyParser = bodyParser.json();
-			var totalRequests = 0;
+			const _bodyParser = bodyParser.json();
+			let totalRequests = 0;
 
 			res.setHeader('Content-Type', 'application/json');
 
@@ -34,10 +34,10 @@ module.exports = function(port) {
 			}
 
 			_bodyParser(req, res, function(err) {
-				var data = req.body.testingData;
-				var reqMethod = req.method;
-				var reqUrl = req.url;
-				var dataCheck = data === 'test data';
+				const data = req.body.testingData;
+				const reqMethod = req.method;
+				const reqUrl = req.url;
+				const dataCheck = data === 'test data';
 
 				if (err) {
 					throw new Error('problem with bodyParser');

--- a/test/specs/fn-http-methods.js
+++ b/test/specs/fn-http-methods.js
@@ -6,30 +6,30 @@
  */
 
 const expect = require('chai').expect;
-const sinon = require('sinon');
-const mockServer = require('../mock-server');
 const FuelRest = require('../../lib/fuel-rest');
-const port = 4550;
+const mockServer = require('../mock-server');
 const routes = require('../config').routes;
+const sinon = require('sinon');
 
+const port = 4550;
 const localhost = `http://127.0.0.1:${port}`;
 
-describe('HTTP methods', function() {
+describe('HTTP methods', () => {
 	'use strict';
 
-	var initOptions;
-	var requestOptions;
-	var server;
+	let initOptions;
+	let requestOptions;
+	let server;
 
-	before(function() {
+	before(() => {
 		server = mockServer(port);
 	});
 
-	after(function() {
+	after(() => {
 		server.close();
 	});
 
-	beforeEach(function() {
+	beforeEach(() => {
 		initOptions = {
 			auth: {
 				clientId: 'testing',
@@ -45,19 +45,16 @@ describe('HTTP methods', function() {
 		};
 	});
 
-	describe('GET', function() {
-		it('should deliver a GET + response', function(done) {
-			var apiRequestSpy;
-			var RestClient;
-
-			apiRequestSpy = sinon.spy(FuelRest.prototype, 'apiRequest');
-			RestClient = new FuelRest(initOptions);
+	describe('GET', () => {
+		it('should deliver a GET + response', done => {
+			const apiRequestSpy = sinon.spy(FuelRest.prototype, 'apiRequest');
+			const RestClient = new FuelRest(initOptions);
 
 			// faking auth
 			RestClient.AuthClient.accessToken = 'testForRest';
 			RestClient.AuthClient.expiration = 111111111111;
 
-			RestClient.get({ uri: routes.get }, function(err, data) {
+			RestClient.get({ uri: routes.get }, (err, data) => {
 				// need to make sure we called apiRequest method
 				expect(apiRequestSpy.calledOnce).to.be.true;
 
@@ -70,13 +67,10 @@ describe('HTTP methods', function() {
 		});
 	});
 
-	describe('POST', function() {
-		it('should deliver a POST', function(done) {
-			var apiRequestSpy;
-			var RestClient;
-
-			apiRequestSpy = sinon.spy(FuelRest.prototype, 'apiRequest');
-			RestClient = new FuelRest(initOptions);
+	describe('POST', () => {
+		it('should deliver a POST', done => {
+			const apiRequestSpy = sinon.spy(FuelRest.prototype, 'apiRequest');
+			const RestClient = new FuelRest(initOptions);
 			requestOptions.uri = routes.post;
 
 			// faking auth
@@ -84,7 +78,7 @@ describe('HTTP methods', function() {
 			RestClient.AuthClient.expiration = 111111111111;
 
 			// doing post
-			RestClient.post(requestOptions, function(err, data) {
+			RestClient.post(requestOptions, (err, data) => {
 				// need to make sure we called apiRequest method
 				expect(apiRequestSpy.calledOnce).to.be.true;
 
@@ -97,13 +91,10 @@ describe('HTTP methods', function() {
 		});
 	});
 
-	describe('PUT', function() {
-		it('should deliever an PUT/UPDATE', function(done) {
-			var apiRequestSpy;
-			var RestClient;
-
-			apiRequestSpy = sinon.spy(FuelRest.prototype, 'apiRequest');
-			RestClient = new FuelRest(initOptions);
+	describe('PUT', () => {
+		it('should deliever an PUT/UPDATE', done => {
+			const apiRequestSpy = sinon.spy(FuelRest.prototype, 'apiRequest');
+			const RestClient = new FuelRest(initOptions);
 			requestOptions.uri = routes.put;
 
 			// faking auth
@@ -111,7 +102,7 @@ describe('HTTP methods', function() {
 			RestClient.AuthClient.expiration = 111111111111;
 
 			// doing post
-			RestClient.put(requestOptions, function(err, data) {
+			RestClient.put(requestOptions, (err, data) => {
 				// need to make sure we called apiRequest method
 				expect(apiRequestSpy.calledOnce).to.be.true;
 
@@ -124,13 +115,10 @@ describe('HTTP methods', function() {
 		});
 	});
 
-	describe('PATCH', function() {
-		it('should deliever an PATCH', function(done) {
-			var apiRequestSpy;
-			var RestClient;
-
-			apiRequestSpy = sinon.spy(FuelRest.prototype, 'apiRequest');
-			RestClient = new FuelRest(initOptions);
+	describe('PATCH', () => {
+		it('should deliever an PATCH', done => {
+			const apiRequestSpy = sinon.spy(FuelRest.prototype, 'apiRequest');
+			const RestClient = new FuelRest(initOptions);
 			requestOptions.uri = routes.patch;
 
 			// faking auth
@@ -138,7 +126,7 @@ describe('HTTP methods', function() {
 			RestClient.AuthClient.expiration = 111111111111;
 
 			// doing post
-			RestClient.patch(requestOptions, function(err, data) {
+			RestClient.patch(requestOptions, (err, data) => {
 				// need to make sure we called apiRequest method
 				expect(apiRequestSpy.calledOnce).to.be.true;
 
@@ -151,13 +139,10 @@ describe('HTTP methods', function() {
 		});
 	});
 
-	describe('DELETE', function() {
-		it('should deliever an DELETE', function(done) {
-			var apiRequestSpy;
-			var RestClient;
-
-			apiRequestSpy = sinon.spy(FuelRest.prototype, 'apiRequest');
-			RestClient = new FuelRest(initOptions);
+	describe('DELETE', () => {
+		it('should deliever an DELETE', done => {
+			const apiRequestSpy = sinon.spy(FuelRest.prototype, 'apiRequest');
+			const RestClient = new FuelRest(initOptions);
 			requestOptions.uri = routes.delete;
 
 			// faking auth
@@ -165,7 +150,7 @@ describe('HTTP methods', function() {
 			RestClient.AuthClient.expiration = 111111111111;
 
 			// doing post
-			RestClient.delete(requestOptions, function(err, data) {
+			RestClient.delete(requestOptions, (err, data) => {
 				// need to make sure we called apiRequest method
 				expect(apiRequestSpy.calledOnce).to.be.true;
 

--- a/test/specs/general-tests.js
+++ b/test/specs/general-tests.js
@@ -12,10 +12,10 @@ const FuelAuth = require('fuel-auth');
 const FuelRest = require('../../lib/fuel-rest');
 const sinon = require('sinon');
 
-describe('General Tests', function() {
+describe('General Tests', () => {
 	var options;
 
-	beforeEach(function() {
+	beforeEach(() => {
 		options = {
 			auth: {
 				clientId: 'testing',
@@ -24,11 +24,11 @@ describe('General Tests', function() {
 		};
 	});
 
-	it('should be a constructor', function() {
+	it('should be a constructor', () => {
 		expect(FuelRest).to.be.a('function');
 	});
 
-	it('should require auth options', function() {
+	it('should require auth options', () => {
 		var RestClient;
 
 		try {
@@ -43,7 +43,7 @@ describe('General Tests', function() {
 		expect(RestClient.AuthClient instanceof FuelAuth).to.be.true;
 	});
 
-	it('should use already initialized fuel auth client', function() {
+	it('should use already initialized fuel auth client', () => {
 		var AuthClient;
 		var RestClient;
 
@@ -56,7 +56,7 @@ describe('General Tests', function() {
 		expect(RestClient.AuthClient.test).to.be.true;
 	});
 
-	it('should take a custom rest endpoint', function() {
+	it('should take a custom rest endpoint', () => {
 		var RestClient;
 
 		// testing default initialization
@@ -72,7 +72,7 @@ describe('General Tests', function() {
 		expect(RestClient.origin).to.equal('https://www.exacttarget.com');
 	});
 
-	it('should merge module level headers into default headers', function() {
+	it('should merge module level headers into default headers', () => {
 		var RestClient;
 
 		options.headers = {
@@ -85,46 +85,46 @@ describe('General Tests', function() {
 		expect(RestClient.defaultHeaders.test).to.equal(1);
 	});
 
-	it('should have apiRequest on prototype', function() {
+	it('should have apiRequest on prototype', () => {
 		expect(FuelRest.prototype.apiRequest).to.be.a('function');
 	});
 
-	it('should have get on prototype', function() {
+	it('should have get on prototype', () => {
 		expect(FuelRest.prototype.get).to.be.a('function');
 	});
 
-	it('should have post on prototype', function() {
+	it('should have post on prototype', () => {
 		expect(FuelRest.prototype.post).to.be.a('function');
 	});
 
-	it('should have put on prototype', function() {
+	it('should have put on prototype', () => {
 		expect(FuelRest.prototype.put).to.be.a('function');
 	});
 
-	it('should have delete on prototype', function() {
+	it('should have delete on prototype', () => {
 		expect(FuelRest.prototype.delete).to.be.a('function');
 	});
 
-	describe('promise integration', function(done) {
-		it('should allow for use of promises', function() {
+	describe('promise integration', () => {
+		it('should allow for use of promises', done => {
 			var RestClient = new FuelRest(options);
 
-			sinon.stub(RestClient, '_processRequest', function(options, callback) {
+			sinon.stub(RestClient, '_processRequest', (options, callback) => {
 				callback(null, { data: true });
 			});
 
-			RestClient.apiRequest({}).then(function(res) {
+			RestClient.apiRequest({}).then(res => {
 				expect(res.data).to.be.true;
 				done();
 			});
 		});
 
-		it('should not allow for use of callbacks and promises together', function() {
+		it('should not allow for use of callbacks and promises together', () => {
 			var error = null;
 			var RestClient = new FuelRest(options);
 
 			try {
-				RestClient.apiRequest({}, function() {}).then(function() {});
+				RestClient.apiRequest({}, () => {}).then(() => {});
 			} catch (err) {
 				error = err;
 			}

--- a/test/specs/helpers.js
+++ b/test/specs/helpers.js
@@ -13,94 +13,82 @@ const helpers = require('../../lib/helpers');
 const sampleResponses = require('../sample-responses');
 const url = require('url');
 
-describe('helpers', function() {
-	describe('isValid401', function() {
-		it('should return true if 401 and token failure', function() {
-			var res;
-			var result;
-
-			res = {
+describe('helpers', () => {
+	describe('isValid401', () => {
+		it('should return true if 401 and token failure', () => {
+			const res = {
 				statusCode: 401,
 				headers: {
 					'www-authenticate': sampleResponses.invalidToken
 				}
 			};
 
-			result = helpers.isValid401(res);
+			const result = helpers.isValid401(res);
 			expect(result).to.be.true;
 		});
 
-		it('should return false if 401 and no token failure', function() {
-			var res;
-			var result;
-
-			res = {
+		it('should return false if 401 and no token failure', () => {
+			const res = {
 				statusCode: 401,
 				headers: {}
 			};
 
-			result = helpers.isValid401(res);
+			const result = helpers.isValid401(res);
 			expect(result).to.be.false;
 		});
 
-		it('should return false if not 401', function() {
-			var res;
-			var result;
-
-			res = {
+		it('should return false if not 401', () => {
+			const res = {
 				statusCode: 200,
 				headers: {}
 			};
 
-			result = helpers.isValid401(res);
+			const result = helpers.isValid401(res);
 			expect(result).to.be.false;
 		});
 
-		it('should return false if no headers passed', function() {
-			var res;
-			var result;
-
-			res = {
+		it('should return false if no headers passed', () => {
+			const res = {
 				statusCode: 401
 			};
 
-			result = helpers.isValid401(res);
+			const result = helpers.isValid401(res);
 			expect(result).to.be.false;
 		});
 	});
 
-	describe('resolveUri', function() {
-		var origin;
-		var resolveSpy;
-		var uri;
+	describe('resolveUri', () => {
+		let origin;
+		let resolveSpy;
+		let uri;
 
-		beforeEach(function() {
+		beforeEach(() => {
 			origin = 'http://test.com';
 			resolveSpy = sinon.stub(url, 'resolve');
 			uri = 'path/to/test';
 		});
 
-		afterEach(function() {
+		afterEach(() => {
 			url.resolve.restore();
 		});
 
-		it('should resolve a URI if origin and uri passed', function() {
+		it('should resolve a URI if origin and uri passed', () => {
 			helpers.resolveUri(origin, uri);
 			expect(resolveSpy.calledOnce).to.be.true;
 		});
 
-		it('should not resolve if URI has http in it', function() {
+		it('should not resolve if URI has http in it', () => {
 			uri = origin + uri;
 			helpers.resolveUri(origin, uri);
 			expect(resolveSpy.calledOnce).to.be.false;
 		});
 
-		it('should not resolve if no origin is passed', function() {
+		it('should not resolve if no origin is passed', () => {
 			helpers.resolveUri(null, uri);
 			expect(resolveSpy.calledOnce).to.be.false;
 		});
 
-		it('should not resolve if no URI is passed', function() {
+		it('should not resolve if no URI is passed', () => {
 			helpers.resolveUri(origin, null);
 			expect(resolveSpy.calledOnce).to.be.false;
 		});


### PR DESCRIPTION
- use FuelAuth `getAccessToken` promise method version internally
- modernise tests (es6)