### PR TITLE
Adding support for OAuth2

### DIFF
--- a/lib/fuel-rest.js
+++ b/lib/fuel-rest.js
@@ -99,6 +99,9 @@ class FuelRest {
 				const headers = options.headers;
 
 				options.uri = helpers.resolveUri(this.origin, options.uri);
+				if(this.AuthClient.authVersion === 2){
+					options.uri = helpers.resolveUriForAuth2(options.uri, tokenInfo.rest_instance_url);
+				}
 				options.headers = Object.assign({}, this.defaultHeaders, options.headers, {
 					// on a retry, the auth header is removed, so this will only add the header passed in
 					// if it's not the retry

--- a/lib/fuel-rest.js
+++ b/lib/fuel-rest.js
@@ -100,7 +100,7 @@ class FuelRest {
 
 				options.uri = helpers.resolveUri(this.origin, options.uri);
 				if(this.AuthClient.authVersion === 2){
-					options.uri = helpers.resolveUriForAuth2(options.uri, tokenInfo.rest_instance_url);
+					options.uri = helpers.resolveUriForOAuth2(options.uri, tokenInfo.rest_instance_url);
 				}
 				options.headers = Object.assign({}, this.defaultHeaders, options.headers, {
 					// on a retry, the auth header is removed, so this will only add the header passed in

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -25,5 +25,8 @@ module.exports = {
 			uri = url.resolve(origin, uri);
 		}
 		return uri;
+	},
+	resolveUriForAuth2(uri, restUrl) {
+		return restUrl + (/\.com(.*)$/g).exec(uri)[1];
 	}
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -26,7 +26,8 @@ module.exports = {
 		}
 		return uri;
 	},
-	resolveUriForAuth2(uri, restUrl) {
-		return restUrl + (/\.com(.*)$/g).exec(uri)[1];
+	resolveUriForOAuth2(uri, restUrl) {
+		let urlParts = uri.toLowerCase().split(".com/");
+		return restUrl + urlParts[1];
 	}
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fuel-rest",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Node library for performing REST API calls to Salesforce Marketing Cloud (formerly ExactTarget).",
   "main": "./lib/fuel-rest.js",
   "scripts": {

--- a/test/specs/helpers.js
+++ b/test/specs/helpers.js
@@ -93,4 +93,16 @@ describe('helpers', () => {
 			expect(resolveSpy.calledOnce).to.be.false;
 		});
 	});
+
+	describe("resolveUriForOAuth2", () => {
+		it('should resolve an URI for OAuth2', () => {
+			let result = helpers.resolveUriForOAuth2('https://www.exacttargetapis.com/hub/v1/campaigns','https://abc.rest.marketingcloudqaapis.com/');
+			expect(result).to.equal('https://abc.rest.marketingcloudqaapis.com/hub/v1/campaigns');
+		});
+
+		it('should resolve an URI for OAuth2 indifferent of casing', () => {
+			let result = helpers.resolveUriForOAuth2('https://www.exacttargetapis.COM/hub/v1/campaigns','https://abc.rest.marketingcloudqaapis.com/');
+			expect(result).to.equal('https://abc.rest.marketingcloudqaapis.com/hub/v1/campaigns');
+		});
+	});
 });


### PR DESCRIPTION
Change is to fetch Rest Tenant Specific endpoint from the OAuth2 token call when customer use OAuth2 authentication.