### PR TITLE
Add support for node LTS to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: node_js
 node_js:
 - '6'
 - '8'
-- '10'
-- stable
+- lts/*
+- node
 sudo: false
 before_install:
   - export PATH=$PATH:`yarn global bin`

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
 - '6'
 - '8'
+- '10'
 - stable
 sudo: false
 before_install:


### PR DESCRIPTION
As [NodeJS v8 has fallen out of maintenance mode](https://nodejs.org/en/about/releases/) I think it's important to keep testing against the current LTS versions 10 and 12.

Also, the updated to the [recommended way of testing against the NodeJS stable](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions) using just `node`.

Would be nice to see a deprecation of NodeJS v6 ASAP and a plan to remove NodeJS v8 in the coming months.